### PR TITLE
Improve documentation around configuring specific fixers

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -1,42 +1,45 @@
 # Configuration
 
-StyleCI provides two ways to configure your repos. You can apply configuration either by committing a `.styleci.yml` file to the project's root, or by visiting its settings page on our site (accessible by the gear icon to the repo name's right on your homepage) and applying it there.
+StyleCI provides two ways to configure your repos. Choose the one that suits you best.
 
-Configuration is formatted as a series of [keys and values](#format-appendix).
+<a name="file-based"></a>
+## File Based
 
-> {warn} Setting configuration through the browser will override all config set in the `.styleci.yml` file.
+You can apply configuration by commiting a `.styleci.yml` file to your project's root. The configuration file uses the [YAML format](https://yaml.org/spec/1.2/spec.html#Preview).
 
 <!-- -->
 > {danger} If you want to use our PHP header checking facility, you must configure that part on the settings page; it's the only part of the configuration not available through the `.styleci.yml` file.
+
+<a name="browser-based"></a>
+## Browser Based
+
+You can configure the settings for a repository by opening your dashboard and clicking the gear icon right next to your repository.
+
+> {warn} Setting configuration through the browser will override all config set in the `.styleci.yml` file.
 
 <a name="choosing-languages"></a>
 ## Choosing Languages
 
 If you're on a newer paid plan, then you'll have access to support for fixing PHP, JS, CSS, Vue.js, Python, and more. If you're on the open source plan, then you'll get support for standalone PHP.
 
-The configuration format differs significantly between PHP and other languages. As well as this, the format used for multiple languages rather than just PHP will only be accepted if your plan supports it.
+The configuration format differs significantly between PHP and other languages. Also, the format used for multiple languages rather than just PHP will only be accepted if your plan supports it.
 
 > {info} By default, we will assume you have a PHP repo, and so if you provide no config, you will get all the defaults.
 
-<a name="fixing-strategies"></a>
-## Fixing Strategies
-
-Our PHP fixing works by applying [fixers](fixers) to files that fix specific things. By comparison, support for other, newer languages works differently by reprinting the entire file. For these languages it may seem like less is being fixed due to a lack of options, but this is not the case; many fixes for these languages occur internally, and don't require the same depth of control as what our PHP service provides.
-
 <a name="php-only-mode"></a>
-## PHP-Only Mode
+### PHP-Only Mode
 
 If you happen to be using an open-source plan, you will have access to PHP-only features. These are detailed [here](standalone-php).
 
 <a name="multi-languages-mode"></a>
-## Multi-Language Mode
+### Multi-Language Mode
 
 If you have a paid plan, you'll have access to configuration features for every language StyleCI supports. Find out more about these options [here](multi-language).
 
 <a name="default-configuration"></a>
 ## Default Configuration
 
-Our default (PHP-only) configuration, used to define any keys you've omitted, is as follows:
+Our default (PHP-only) configuration looks like this:
 
 ```yaml
 preset: recommended
@@ -50,6 +53,8 @@ finder:
   name: "*.php"
   not-name: "*.blade.php"
 ```
+
+You only need to define the configuration options you want to override, any other options are merged with the default.
 
 You can read more about each option [here](standalone-php); in essence, the default mode uses recommended fixers and ignores paths and file suffixes that are usually undesirable to fix.
 
@@ -65,32 +70,3 @@ py: false
 ```
 
 You can read more about each option [here](multi-language). It simply disables all languages other than PHP, using its default settings above.
-
-<a name="format-appendix"></a>
-## Format Appendix
-
-Configuration is formatted as a series of keys and their values, like the following:
-
-```yaml
-key1:
-  key2:
-    - value1
-    - value2
-  key3:
-    - value3
-key4:
-  - value4
-```
-
-As can be seen, `key4` has a single value (`value4`) and `key1` has two sub-keys (`key2` and `key3`), each of which have their own values (`value1`+`value2` and `value3`, respectively). A StyleCI configuration, written like above in either your `.styleci.yml` file or in the settings page, thus forms a tree of nested options.
-
-Note that the final bullet-point lists of values cannot themselves be nested. If there is only one element in them, you can omit the bullet like so:
-
-```yaml
-key1:
-  key2:
-    - value1
-    - value2
-  key3: value3
-key4: value4
-```

--- a/fixers.md
+++ b/fixers.md
@@ -1,6 +1,21 @@
 # PHP Fixers
 
-We have many available fixers. Note that while header comment fixing is available in StyleCI, we do not consider it a "fixer" as isn't configured as a fixer. Header comment fixing has it's own dedicated config on the settings page for your repo.
+Our PHP fixing works by applying single-purposed transformations to files that fix specific issues.
+
+Depending upon the [preset](presets), a default set of fixers will be included.
+If you want more granular control, you can enable or disable specific fixers by adding them to your configuration:
+
+```diff
+preset: recommended
+enabled:
+  - no_superfluous_phpdoc_tags
++ - declare_strict_types
+disabled:
+  - align_double_arrow
+- - include
+```
+
+> {danger} If you want to use our PHP header checking facility, you must configure that part on the settings page; it's the only part of the configuration not available through the `.styleci.yml` file.
 
 __STYLECI_FIXER_DOCS__
 

--- a/fixers.md
+++ b/fixers.md
@@ -5,14 +5,14 @@ Our PHP fixing works by applying single-purposed transformations to files that f
 Depending upon the [preset](presets), a default set of fixers will be included.
 If you want more granular control, you can enable or disable specific fixers by adding them to your configuration:
 
-```diff
+```yaml
 preset: recommended
 enabled:
   - no_superfluous_phpdoc_tags
-+ - declare_strict_types
+  - declare_strict_types
 disabled:
   - align_double_arrow
-- - include
+  - include
 ```
 
 > {danger} If you want to use our PHP header checking facility, you must configure that part on the settings page; it's the only part of the configuration not available through the `.styleci.yml` file.


### PR DESCRIPTION
Thanks for this great service.

I am always having a hard time when i am writing a StyleCI configuration file.

When i visit https://docs.styleci.io/fixers to look for a specific option, it does not specify where and how i can actually enable that option. The only actual code example of enabling/disabling a fixer is found on https://docs.styleci.io/multi-language

This PR adds a short introductory paragraph that shows a quick example of how fixers can be configured.

Also, i edited the configuration page to give more succinct, focused information that is directed towards getting a working configuration up and running.